### PR TITLE
Update config.php

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -60,10 +60,7 @@
 // Add JS file
 if(TL_MODE == 'BE')
 {
-	$ordnerscan = scandir('../assets/jquery/core/'); // jQuery-Ordner durchsuchen.
-	//letzten Ordner/Version nutzen
-	
-    $GLOBALS['TL_JAVASCRIPT'][] = 'assets/jquery/core/'.$ordnerscan[count($ordnerscan)-1].'/jquery.min.js';
+    	$GLOBALS['TL_JAVASCRIPT'][] = 'assets/jquery/core/' . $GLOBALS['TL_ASSETS']['JQUERY'] . '/jquery.min.js|static';
 	$GLOBALS['TL_JAVASCRIPT'][] = 'system/modules/be__jQuery/assets/noconflict.js';
 } 
 


### PR DESCRIPTION
Seit dem Versionssprung von 1.9 auf 1.10 wird trotzdem 1.9 eingebunden. Durch $GLOBALS['TL_ASSETS']['JQUERY'] wird die hinterlegte jQuery Version aus dem Core-Modul genutzt.
